### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
   "icon_background": "#FFFFFF",
   "icon_cover": false,
   "icon": "https://github.com/supervisely-ecosystem/batched-smart-tool-for-videos/releases/download/v0.0.1/logo.png",
-  "instance_version": "6.8.88",
+  "instance_version": "6.15.60",
   "context_menu": {
     "target": [
       "videos_project"

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "labeling"
   ],
   "description": "Batched smart labeling tool for Videos",
-  "docker_image": "supervisely/labeling:6.73.45",
+  "docker_image": "supervisely/labeling:6.73.564",
   "entrypoint": "python -m uvicorn src.main:g.app --host 0.0.0.0 --port 8000",
   "port": 8000,
   "task_location": "workspace_tasks",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-supervisely[apps]==6.35.0
+supervisely[apps]==6.73.564
 
 imutils==0.5.4
 loguru==0.6.0


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
